### PR TITLE
新增資料庫支援與管理員帳號初始化

### DIFF
--- a/MyPocket.DataAccess/Data/DbInitializer.cs
+++ b/MyPocket.DataAccess/Data/DbInitializer.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore;
+using MyPocket.Core.Models;
+
+namespace MyPocket.DataAccess.Data
+{
+    public static class DbInitializer
+    {
+        public static async Task Initialize(MyPocketDBContext context)
+        {
+            await context.Database.EnsureCreatedAsync();
+
+            if (await context.Users.AnyAsync(u => u.Role == "Admin"))
+            {
+                return; 
+            }
+
+            var adminPasswordHash = BCrypt.Net.BCrypt.HashPassword("12345678");
+
+            var adminUser = new User
+            {
+                UserId = Guid.NewGuid(),
+                Email = "admin@example.com",
+                PasswordHash = adminPasswordHash,
+                Nickname = "管理員",
+                Role = "Admin",
+                CreationDate = DateTime.UtcNow,
+                LastLoginDate = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+                IsDeleted = false
+            };
+
+            await context.Users.AddAsync(adminUser);
+            await context.SaveChangesAsync();
+
+        }
+    }
+}

--- a/MyPocket.DataAccess/MyPocket.DataAccess.csproj
+++ b/MyPocket.DataAccess/MyPocket.DataAccess.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.7">
       <PrivateAssets>all</PrivateAssets>

--- a/MyPocket.Web/MyPocket.Web.csproj
+++ b/MyPocket.Web/MyPocket.Web.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.7">
       <PrivateAssets>all</PrivateAssets>
@@ -21,7 +22,6 @@
 
   <ItemGroup>
     <Folder Include="Areas\User\Controllers\" />
-    <Folder Include="Areas\User\Views\" />
   </ItemGroup>
 
 </Project>

--- a/MyPocket.Web/Program.cs
+++ b/MyPocket.Web/Program.cs
@@ -21,10 +21,26 @@ builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationSc
 
 var app = builder.Build();
 
+using (var scope = app.Services.CreateScope())
+{
+    var services = scope.ServiceProvider;
+    try
+    {
+        var context = services.GetRequiredService<MyPocketDBContext>();
+        await DbInitializer.Initialize(context);
+    }
+    catch (Exception ex)
+    {
+        var logger = services.GetRequiredService<ILogger<Program>>();
+        logger.LogError(ex, "An error occurred while seeding the database.");
+    }
+}
+
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())
 {
     app.UseExceptionHandler("/Home/Error");
+    app.UseHsts();
 }
 app.UseStaticFiles();
 


### PR DESCRIPTION
在 `MyPocket.DataAccess.csproj` 和 `MyPocket.Web.csproj` 中新增 `BCrypt.Net-Next` 套件以支援密碼雜湊和資料庫操作。

在 `AccountController.cs` 中實作依賴注入，修改登入邏輯以從資料庫查詢使用者並驗證密碼，根據角色重定向至相應頁面。

在 `Program.cs` 中新增資料庫初始化邏輯，確保應用啟動時資料庫已建立並有預設的管理員帳號。

在 `DbInitializer.cs` 中新增靜態類別以檢查並創建管理員帳號。