### PR TITLE
調整 cloudbuild.yaml 中的 Docker 建置目錄

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,8 +1,8 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/mypocket-web', './MyPocket.Web']
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/mypocket-web', '.']
   id: Build
-  dir: '.'
+  dir: 'MyPocket.Web'
 - name: 'gcr.io/cloud-builders/docker'
   args: ['push', 'gcr.io/$PROJECT_ID/mypocket-web']
   id: Push


### PR DESCRIPTION
將 Docker 建置步驟的目錄從 `./MyPocket.Web` 更改為 `.`，並新增 `dir: 'MyPocket.Web'` 以指定建置目錄。推送步驟保持不變，仍然將映像推送到 Google Container Registry。