### PR TITLE
新增開發環境資料庫連接字串設定

### DIFF
--- a/MyPocket.Web/appsettings.Development.json
+++ b/MyPocket.Web/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "ConnectionStrings": {
+    "MyPocketDBConnection": "Data Source=35.221.140.252;Database=MyPocketDB;TrustServerCertificate=True;User ID=sqlserver;Password=12345678"
   }
 }

--- a/MyPocket.Web/appsettings.json
+++ b/MyPocket.Web/appsettings.json
@@ -5,8 +5,5 @@
             "Microsoft.AspNetCore": "Warning"
         }
     },
-    "AllowedHosts": "*",
-  "ConnectionStrings": {
-    "MyPocketDBConnection": "Data Source=35.221.140.252;Database=MyPocketDB;TrustServerCertificate=True;User ID=sqlserver;Password=12345678"
-  }
+    "AllowedHosts": "*"
 }


### PR DESCRIPTION
在 `appsettings.Development.json` 中，新增了 `ConnectionStrings` 部分，包含 `MyPocketDBConnection` 的連接字串，以便開發環境能夠連接到指定的資料庫。

在 `appsettings.json` 中，刪除了 `ConnectionStrings` 部分，生產環境不再包含該資料庫的連接字串設定，但保留了 `AllowedHosts` 的設定。