### PR TITLE
移除重複字串並新增驗證錯誤訊息

### DIFF
--- a/MyPocket.Shared/Resources/locales/zh-TW.json
+++ b/MyPocket.Shared/Resources/locales/zh-TW.json
@@ -18,5 +18,7 @@
   "Privacy": "隱私權政策",
   "Login": "登入",
   "Register": "註冊",
-  "Logout": "登出"
+  "Logout": "登出",
+  "CompareAttribute_ValidationError": "「{0}」與「{1}」不相符。",
+  "RequiredAttribute_ValidationError": "「{0}」為必填欄位。"
 }


### PR DESCRIPTION
在 `zh-TW.json` 檔案中，移除了重複的 "登出" 字串。新增了兩個驗證錯誤訊息的翻譯，分別為「{0}」與「{1}」不相符，以及「{0}」為必填欄位。