### PR TITLE
更新註冊頁面佈局與樣式

### DIFF
--- a/MyPocket.Web/Views/Account/Register.cshtml
+++ b/MyPocket.Web/Views/Account/Register.cshtml
@@ -1,44 +1,45 @@
-@* @model MyPocket.Shared.ViewModels.Accounts.RegisterViewModel
+@model MyPocket.Shared.ViewModels.Accounts.RegisterViewModel
 
 @{
     ViewData["Title"] = "註冊";
+    Layout = "~/Views/Shared/_LayoutGuest.cshtml";
 }
 
 <h1>註冊</h1>
 <hr />
 <div class="row">
-    <div class="col-md-4">
-        <form asp-action="Register" method="post">
+    <div class="col-md-6 col-lg-5">
+        <form asp-action="Register" method="post" autocomplete="off">
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-            <div class="form-group">
-                <label asp-for="Email" class="control-label"></label>
-                <input asp-for="Email" class="form-control" />
+            <div class="form-group mb-3">
+                <label asp-for="Email" class="form-label"></label>
+                <input asp-for="Email" class="form-control" autocomplete="username" />
                 <span asp-validation-for="Email" class="text-danger"></span>
             </div>
-            <div class="form-group">
-                <label asp-for="Password" class="control-label"></label>
-                <input asp-for="Password" class="form-control" type="password" />
+            <div class="form-group mb-3">
+                <label asp-for="Password" class="form-label"></label>
+                <input asp-for="Password" class="form-control" type="password" autocomplete="new-password" />
                 <span asp-validation-for="Password" class="text-danger"></span>
             </div>
-            <div class="form-group">
-                <label asp-for="ConfirmPassword" class="control-label"></label>
-                <input asp-for="ConfirmPassword" class="form-control" type="password" />
+            <div class="form-group mb-3">
+                <label asp-for="ConfirmPassword" class="form-label"></label>
+                <input asp-for="ConfirmPassword" class="form-control" type="password" autocomplete="new-password" />
                 <span asp-validation-for="ConfirmPassword" class="text-danger"></span>
             </div>
-            <div class="form-group">
-                <label for="Username" class="control-label">Username</label>
-                <input id="Username" name="Nickname" class="form-control" value="@Model?.Nickname" />
+            <div class="form-group mb-3">
+                <label asp-for="Nickname" class="form-label"></label>
+                <input asp-for="Nickname" class="form-control" />
                 <span asp-validation-for="Nickname" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <input type="submit" value="註冊" class="btn btn-primary" />
+                <input type="submit" value="註冊" class="btn btn-primary w-100" />
             </div>
         </form>
     </div>
 </div>
-<div>
+<div class="mt-3">
     <a asp-action="Login">已有帳號？登入</a>
 </div>
 @section Scripts {
     @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
-} *@
+}


### PR DESCRIPTION
將註冊頁面的佈局更改為使用 `_LayoutGuest.cshtml`，並調整表單結構以提升響應性。新增 `autocomplete` 屬性以改善用戶體驗，並調整了輸入框的樣式和間距。用戶名輸入框改為使用 `asp-for` 綁定，並更新提交按鈕的寬度。最後，增加了與登入連結的間距。