### PR TITLE
移除確認密碼驗證並改善類別選擇功能

### DIFF
--- a/MyPocket.Shared/ViewModels/Accounts/RegisterViewModel.cs
+++ b/MyPocket.Shared/ViewModels/Accounts/RegisterViewModel.cs
@@ -15,7 +15,6 @@ namespace MyPocket.Shared.ViewModels.Accounts
 
         [Required]
         [DataType(DataType.Password)]
-        [Compare("Password", ErrorMessage = "密碼與確認密碼不一致")]
         public string ConfirmPassword { get; set; } = null!;
 
         public string? Nickname { get; set; }

--- a/MyPocket.Web/Areas/User/Views/Transactions/CreatePartial.cshtml
+++ b/MyPocket.Web/Areas/User/Views/Transactions/CreatePartial.cshtml
@@ -1,6 +1,7 @@
 @model IEnumerable<MyPocket.Core.Models.Transaction>
 @{
     var categoryError = ViewData.ModelState["CategoryId"]?.Errors.FirstOrDefault()?.ErrorMessage;
+    var categories = ViewBag.Categories as IEnumerable<SelectListItem>;
 }
 <div class="card shadow-sm">
     <div class="card-body">
@@ -11,14 +12,21 @@
                 <label for="CategoryId" class="form-label">類別 <span class="text-danger">*</span></label>
                 <select name="CategoryId" id="CategoryId" class="form-select" required>
                     <option value="">-- 選擇類別 --</option>
-                    @foreach (var categoryGroup in ((IEnumerable<SelectListItem>)ViewBag.Categories).GroupBy(c => c.Group.Name))
+                    @if (categories != null && categories.Any())
                     {
-                        <optgroup label="@categoryGroup.Key">
-                            @foreach (var category in categoryGroup)
-                            {
-                                <option value="@category.Value">@category.Text</option>
-                            }
-                        </optgroup>
+                        foreach (var categoryGroup in categories.GroupBy(c => c.Group.Name))
+                        {
+                            <optgroup label="@categoryGroup.Key">
+                                @foreach (var category in categoryGroup)
+                                {
+                                    <option value="@category.Value">@category.Text</option>
+                                }
+                            </optgroup>
+                        }
+                    }
+                    else
+                    {
+                        <option value="">搜尋不到類別</option>
                     }
                 </select>
                 @if (!string.IsNullOrEmpty(categoryError))


### PR DESCRIPTION
在 `RegisterViewModel.cs` 中，移除了 `ConfirmPassword` 屬性上的 `Compare` 特性，這可能意味著不再需要確認密碼的驗證。

在 `CreatePartial.cshtml` 中，新增了對 `ViewBag.Categories` 的檢查，並在選擇類別的下拉選單中，根據 `categories` 變數進行分組顯示。若沒有可用的類別，則顯示「搜尋不到類別」的提示。