### PR TITLE
新增日誌記錄以改善調試資訊

### DIFF
--- a/MyPocket.Services/CategoryService.cs
+++ b/MyPocket.Services/CategoryService.cs
@@ -17,7 +17,19 @@ namespace MyPocket.Services
 
         public async Task<UserCategoryViewModel> GetUserCategoriesAsync(Guid userId)
         {
+            // 記錄傳入的 userId
+            System.Diagnostics.Debug.WriteLine($"CategoryService called with userId: {userId}");
+            System.Diagnostics.Debug.WriteLine($"Hardcoded AdminUserId: {AdminUserId}");
+
             var categories = await _context.Categories.Where(c => !c.IsDeleted).ToListAsync();
+
+            // 記錄篩選後的類別數量
+            System.Diagnostics.Debug.WriteLine($"Total categories from DB: {categories.Count}");
+            System.Diagnostics.Debug.WriteLine($"DefaultIncomeCategories count: {categories.Count(c => c.UserId == AdminUserId && c.CategoryType == "收入")}");
+            System.Diagnostics.Debug.WriteLine($"DefaultExpenseCategories count: {categories.Count(c => c.UserId == AdminUserId && c.CategoryType == "支出")}");
+            System.Diagnostics.Debug.WriteLine($"UserIncomeCategories count: {categories.Count(c => c.UserId == userId && c.CategoryType == "收入")}");
+            System.Diagnostics.Debug.WriteLine($"UserExpenseCategories count: {categories.Count(c => c.UserId == userId && c.CategoryType == "支出")}");
+
             return new UserCategoryViewModel
             {
                 DefaultIncomeCategories = categories.Where(c => c.UserId == AdminUserId && c.CategoryType == "收入").ToList(),

--- a/MyPocket.Web/Areas/User/Controllers/TransactionsController.cs
+++ b/MyPocket.Web/Areas/User/Controllers/TransactionsController.cs
@@ -49,6 +49,10 @@ namespace MyPocket.Web.Areas.User.Controllers
             {
                 var userId = GetUserId();
 
+                // 在這裡加入日誌記錄
+                // 這會讓你看到雲端環境中，系統獲取到的 userId 是什麼
+                System.Diagnostics.Debug.WriteLine($"User ID in Index action: {userId}");
+
                 // 獲取交易記錄
                 var transactions = await _transactionService.GetUserTransactionsAsync(userId);
                 


### PR DESCRIPTION
在 `CategoryService.cs` 中，新增多個日誌記錄，追蹤 `userId` 和從資料庫獲取的類別數量，並記錄預設收入和支出類別的計數，以便於調試。

在 `TransactionsController.cs` 中，新增日誌記錄，讓開發人員能在雲端環境中查看 `Index` 方法獲取的用戶 ID，幫助確認系統的正確性。