### PR TITLE
修正 CategoryType 比較方式為不區分大小寫

### DIFF
--- a/MyPocket.Services/CategoryService.cs
+++ b/MyPocket.Services/CategoryService.cs
@@ -32,10 +32,18 @@ namespace MyPocket.Services
 
             return new UserCategoryViewModel
             {
-                DefaultIncomeCategories = categories.Where(c => c.UserId == AdminUserId && c.CategoryType == "收入").ToList(),
-                DefaultExpenseCategories = categories.Where(c => c.UserId == AdminUserId && c.CategoryType == "支出").ToList(),
-                UserIncomeCategories = categories.Where(c => c.UserId == userId && c.CategoryType == "收入").ToList(),
-                UserExpenseCategories = categories.Where(c => c.UserId == userId && c.CategoryType == "支出").ToList()
+                DefaultIncomeCategories = categories
+    .Where(c => c.UserId == AdminUserId && c.CategoryType.Equals("收入", StringComparison.OrdinalIgnoreCase))
+    .ToList(),
+                DefaultExpenseCategories = categories
+    .Where(c => c.UserId == AdminUserId && c.CategoryType.Equals("支出", StringComparison.OrdinalIgnoreCase))
+    .ToList(),
+                UserIncomeCategories = categories
+    .Where(c => c.UserId == userId && c.CategoryType.Equals("收入", StringComparison.OrdinalIgnoreCase))
+    .ToList(),
+                UserExpenseCategories = categories
+    .Where(c => c.UserId == userId && c.CategoryType.Equals("支出", StringComparison.OrdinalIgnoreCase))
+    .ToList(),
             };
         }
 


### PR DESCRIPTION
在 `CategoryService.cs` 中，將對 `CategoryType` 的比較從使用 `==` 改為使用 `Equals` 方法，並指定 `StringComparison.OrdinalIgnoreCase` 參數。這樣的修改提高了代碼的靈活性，確保比較時不會因大小寫不同而導致錯誤的結果。