### PR TITLE
簡化 CategoryType 比較邏輯

### DIFF
--- a/MyPocket.Services/CategoryService.cs
+++ b/MyPocket.Services/CategoryService.cs
@@ -32,18 +32,10 @@ namespace MyPocket.Services
 
             return new UserCategoryViewModel
             {
-                DefaultIncomeCategories = categories
-    .Where(c => c.UserId == AdminUserId && c.CategoryType.Equals("收入", StringComparison.OrdinalIgnoreCase))
-    .ToList(),
-                DefaultExpenseCategories = categories
-    .Where(c => c.UserId == AdminUserId && c.CategoryType.Equals("支出", StringComparison.OrdinalIgnoreCase))
-    .ToList(),
-                UserIncomeCategories = categories
-    .Where(c => c.UserId == userId && c.CategoryType.Equals("收入", StringComparison.OrdinalIgnoreCase))
-    .ToList(),
-                UserExpenseCategories = categories
-    .Where(c => c.UserId == userId && c.CategoryType.Equals("支出", StringComparison.OrdinalIgnoreCase))
-    .ToList(),
+                DefaultIncomeCategories = categories.Where(c => c.UserId == AdminUserId && c.CategoryType == "收入").ToList(),
+                DefaultExpenseCategories = categories.Where(c => c.UserId == AdminUserId && c.CategoryType == "支出").ToList(),
+                UserIncomeCategories = categories.Where(c => c.UserId == userId && c.CategoryType == "收入").ToList(),
+                UserExpenseCategories = categories.Where(c => c.UserId == userId && c.CategoryType == "支出").ToList()
             };
         }
 


### PR DESCRIPTION
將 `Equals` 方法替換為 `==` 運算符，以提高代碼可讀性。此變更影響 `DefaultIncomeCategories`、`DefaultExpenseCategories`、`UserIncomeCategories` 和 `UserExpenseCategories` 的篩選條件。